### PR TITLE
PHPのDockerイメージを7.3に変更する

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2.10-fpm-alpine
+FROM php:7.3.2-fpm-alpine
 
 LABEL maintainer="https://github.com/keitakn"
 
@@ -15,3 +15,5 @@ RUN set -x && \
 COPY config/php.ini /usr/local/etc/php/php.ini
 COPY config/docker-php-ext-opcache.ini /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
 COPY config/docker-php-ext-xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+WORKDIR /opt/qiita-stocker-backend

--- a/php/config/docker-php-ext-opcache.ini
+++ b/php/config/docker-php-ext-opcache.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/opcache.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/opcache.so
 
 opcache.memory_consumption=128
 opcache.interned_strings_buffer=8

--- a/php/config/docker-php-ext-xdebug.ini
+++ b/php/config/docker-php-ext-xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so
 
 xdebug.remote_enable=1
 xdebug.remote_autostart=1


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/docker-compose-boilerplate/issues/11

# Doneの定義
https://github.com/nekochans/docker-compose-boilerplate/issues/11 の完了条件が満たされていること

## 技術的変更点概要
イメージを`php:7.3.2-fpm-alpine`に更新。
作業しやすいように`WORKDIR`の設定も追加。